### PR TITLE
Enable proper parsing of HLS URLs with query string params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore editor files
+*~
+\#*\#
+
+# Ignore OS-specific
+.DS_Store

--- a/index.html
+++ b/index.html
@@ -46,7 +46,8 @@
 								</label>
 							</p>
 							<p>&nbsp;</p>
-							<p><input id="media-url-upload" type="text" placeholder="Enter a URL here" value="https://ldpd-wowza-test1.svc.cul.columbia.edu:8443/vod/mp4:CARN27_v_1_READY_TO_EXPORT.mp4/playlist.m3u8">
+							<p>
+								<input id="media-url-upload" type="text" placeholder="Enter a URL here" value="https://ldpd-wowza-test1.svc.cul.columbia.edu:8443/vod/mp4:CARN27_v_1_READY_TO_EXPORT.mp4/playlist.m3u8">
 								<button id="media-url-submit" class="btn btn-primary" onclick="new OHSynchronizer({player: {url: $('#media-url-upload').val()}});">Submit</button>
 							</p>
 						</div>


### PR DESCRIPTION
Also:
- General refactoring of OHSynchronizer.Import.mediaFromUrl method
- Throw error when a user tries to load an http media resource from an https page context